### PR TITLE
feat(slice-1): health check + smoke tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set base URL
+        run: echo "E2E_BASE_URL=https://example.com" >> $GITHUB_ENV
       - run: npm install
       - run: npm run test:e2e
       - name: Upload coverage

--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+import { View, Text } from "react-native";
+
+export default function App() {
+  const [banner, setBanner] = useState("");
+
+  useEffect(() => {
+    fetch("/.netlify/functions/health")
+      .then((res) => res.ok)
+      .then((ok) => setBanner(ok ? "Health OK" : "Health FAIL"))
+      .catch(() => setBanner("Health FAIL"));
+  }, []);
+
+  return (
+    <View>{banner ? <Text testID="health-banner">{banner}</Text> : null}</View>
+  );
+}

--- a/apps/web/App.tsx
+++ b/apps/web/App.tsx
@@ -1,5 +1,8 @@
-import * as Sentry from 'sentry-expo'
-Sentry.init({ dsn: process.env.SENTRY_DSN })
+import * as Sentry from "sentry-expo";
+import CoreApp from "../app/App";
+
+Sentry.init({ dsn: process.env.SENTRY_DSN });
+
 export default function App() {
-  return null
+  return <CoreApp />;
 }

--- a/functions/health.ts
+++ b/functions/health.ts
@@ -1,0 +1,16 @@
+import { Handler, stream } from "@netlify/functions";
+import { ReadableStream } from "node:stream/web";
+
+export const handler: Handler = async () => {
+  const body = JSON.stringify({ ok: true, ts: Date.now() });
+  const readable = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+      controller.close();
+    },
+  });
+  return stream(readable, {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:unit": "vitest run",
     "test:int": "vitest run tests/integration",
     "test:e2e": "playwright test",
-    "lint": "eslint . --ext .ts,.tsx",
+    "lint": "eslint -c .eslintrc.cjs . --ext .ts,.tsx",
     "typecheck": "tsc -b",
     "gen:test": "node scripts/gen-test.js"
   },
@@ -28,13 +28,13 @@
     }
   },
   "devDependencies": {
-  "eslint": "^8.58.0",
-  "@typescript-eslint/parser": "^6.12.1",
-  "@typescript-eslint/eslint-plugin": "^6.12.1",
-  "eslint-plugin-react": "^7.34.1",
-  "eslint-plugin-react-hooks": "^4.6.0",
-  "eslint-plugin-react-native": "^4.1.0",
-  "eslint-plugin-import": "^2.29.1",
-  "eslint-config-prettier": "^9.1.0"
+    "eslint": "^8.58.0",
+    "@typescript-eslint/parser": "^6.12.1",
+    "@typescript-eslint/eslint-plugin": "^6.12.1",
+    "eslint-plugin-react": "^7.34.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-native": "^4.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-config-prettier": "^9.1.0"
   }
 }

--- a/tests/e2e/health.spec.ts
+++ b/tests/e2e/health.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "@playwright/test";
+
+const base = process.env.E2E_BASE_URL || "http://localhost:8888";
+
+test("banner visible", async ({ page }) => {
+  await page.goto(base);
+  const banner = page.locator('[testID="health-banner"]');
+  await expect(banner).toBeVisible();
+});

--- a/tests/unit/health.test.ts
+++ b/tests/unit/health.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest";
+import { handler } from "../../functions/health";
+
+describe("health function", () => {
+  it("returns status 200", async () => {
+    const res: any = await handler({} as any, {} as any);
+    expect(res.statusCode ?? res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- add Netlify function `health`
- display health banner in shared App and wire web entry
- add unit and e2e smoke tests
- run Playwright in CI with `E2E_BASE_URL`
- tweak lint script for ESLint 9

## Testing
- `npm run lint` *(fails: config incompatible with ESLint 9)*
- `npm run test:unit` *(fails: vitest not found)*
- `npm run test:e2e` *(fails: playwright not found)*