### PR TITLE
fix(build): lockfile + expo web export

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = "npm ci --legacy-peer-deps && npm run build"
-  publish = "apps/app/dist"
+  publish = "web-dist"
   edge_functions = "functions"
 
 [build.environment]

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "test:e2e": "playwright test",
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc -b",
-    "gen:test": "node scripts/gen-test.js"
+    "gen:test": "node scripts/gen-test.js",
+    "web:build": "expo export --platform web --output-dir web-dist",
+    "build": "npm run web:build"
   },
   "lint-staged": {
     "*.{ts,tsx,js,json,md}": "prettier --write"


### PR DESCRIPTION
## Summary
- add Expo web build script
- publish web-dist on Netlify

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck` *(fails: TS5083 Cannot read tsconfig.json)*