### PR TITLE
Add static Coming Soon page and simplified deploy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+on:
+  pull_request:
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: mkdir -p dist
+      - run: cp apps/web/static/index.html dist/index.html
+      - name: Deploy preview
+        id: deploy
+        uses: netlify/actions/cli@v2
+        with:
+          args: deploy --dir=dist --json
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      - name: Save preview URL
+        run: echo ${{ steps.deploy.outputs.deploy-url }} > preview_url.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: preview-url
+          path: preview_url.txt

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,22 @@
+name: Deploy-Prod
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: mkdir -p dist
+      - run: cp apps/web/static/index.html dist/index.html
+      - name: Deploy to Netlify
+        uses: netlify/actions/cli@v2
+        with:
+          args: deploy --dir=dist --prod
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/apps/web/static/index.html
+++ b/apps/web/static/index.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8" />
+<title>Frontier Family Phoenix</title>
+<style>body{font-family:sans-serif;display:grid;place-items:center;height:100vh;margin:0}h1{font-size:2rem}</style>
+</head><body><h1>🚧 Coming Soon — Slice 2 UI 🚧</h1></body></html>


### PR DESCRIPTION
## Summary
- show "Coming Soon" placeholder for Slice 2
- adjust CI and production deploy workflows to copy the placeholder page instead of building

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint . --ext .ts,.tsx` *(fails: eslint-plugin-react not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b56997a5c832fa658510a8e7d2537