### PR TITLE
Fix Netlify preview alias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,16 @@ jobs:
           node-version: '20'
       - run: mkdir -p dist
       - run: cp apps/web/static/index.html dist/index.html
+      - name: Sanitize branch name for Netlify alias
+        id: slug
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          echo "safe=$(echo $BRANCH | tr '/.' '-')" >> $GITHUB_OUTPUT
       - name: Deploy preview
         id: deploy
         uses: netlify/actions/cli@v2
         with:
-          args: deploy --dir=dist --json
+          args: deploy --dir=dist --json --alias ${{ steps.slug.outputs.safe }}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/setup-branch-db.yml
+++ b/.github/workflows/setup-branch-db.yml
@@ -34,11 +34,17 @@ jobs:
           echo "supabase_url=$(supabase db show-url)" >> "$GITHUB_OUTPUT"
           echo "supabase_key=$(supabase db show-api-key)" >> "$GITHUB_OUTPUT"
 
+      - name: Sanitize branch name for Netlify alias
+        id: slug
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          echo "safe=$(echo $BRANCH | tr '/.' '-')" >> $GITHUB_OUTPUT
+
       - name: Build and deploy preview
         id: deploy
         uses: netlify/actions/cli@v2
         with:
-          args: deploy --dir=apps/web/dist --json
+          args: deploy --dir=apps/web/dist --json --alias ${{ steps.slug.outputs.safe }}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
## Summary
- ensure branch names are safe for Netlify
- use sanitized branch names for preview aliases

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c40ddf6fc832f8ebeb6dbe9fa041e